### PR TITLE
Noop Authenticator bypasses pipeline

### DIFF
--- a/api/decision_test.go
+++ b/api/decision_test.go
@@ -68,6 +68,14 @@ func TestDecisionAPI(t *testing.T) {
 	ts := httptest.NewServer(n)
 	defer ts.Close()
 
+	ruleNoOpAuthenticatorWithMutator := rule.Rule{
+		Match:          &rule.Match{Methods: []string{"GET"}, URL: ts.URL + "/authn-noop-mutator/<[0-9]+>"},
+		Authenticators: []rule.Handler{{Handler: "noop"}},
+		Authorizer:     rule.Handler{Handler: "allow"},
+		Mutators:       []rule.Handler{{Handler: "id_token"}},
+		Upstream:       rule.Upstream{URL: ""},
+	}
+
 	ruleNoOpAuthenticator := rule.Rule{
 		Match:          &rule.Match{Methods: []string{"GET"}, URL: ts.URL + "/authn-noop/<[0-9]+>"},
 		Authenticators: []rule.Handler{{Handler: "noop"}},
@@ -122,6 +130,17 @@ func TestDecisionAPI(t *testing.T) {
 			rulesRegexp: []rule.Rule{ruleNoOpAuthenticator, ruleNoOpAuthenticator},
 			rulesGlob:   []rule.Rule{ruleNoOpAuthenticatorGLOB, ruleNoOpAuthenticatorGLOB},
 			code:        http.StatusInternalServerError,
+		},
+		{
+			d:           "should pass and skip mutator with noop authenticator",
+			url:         ts.URL + "/decisions" + "/authn-noop-mutator/1234",
+			rulesRegexp: []rule.Rule{ruleNoOpAuthenticatorWithMutator},
+			rulesGlob:   []rule.Rule{ruleNoOpAuthenticatorWithMutator},
+			code:        http.StatusOK,
+			transform: func(r *http.Request) {
+				r.Header.Add("Authorization", "basic user:pass")
+			},
+			authz: "basic user:pass",
 		},
 		{
 			d:           "should pass",

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -197,6 +197,7 @@ func (d *requestHandler) HandleRequest(r *http.Request, rl *rule.Rule) (session 
 		return nil, err
 	}
 
+	useNoopAuthenticator := false
 	for _, a := range rl.Authenticators {
 		anh, err := d.r.PipelineAuthenticator(a.Handler)
 		if err != nil {
@@ -242,6 +243,10 @@ func (d *requestHandler) HandleRequest(r *http.Request, rl *rule.Rule) (session 
 				return nil, err
 			}
 		} else {
+			// If we hit the no-op authenticator then make a note of it
+			if anh.GetID() == "noop" {
+				useNoopAuthenticator = true
+			}
 			// The first authenticator that matches must return the session
 			found = true
 			fields["subject"] = session.Subject
@@ -257,6 +262,14 @@ func (d *requestHandler) HandleRequest(r *http.Request, rl *rule.Rule) (session 
 			WithField("reason_id", "authentication_handler_no_match").
 			Warn("No authentication handler was responsible for handling the authentication request")
 		return nil, err
+	}
+
+	if useNoopAuthenticator {
+		// This is essentially what the noop mutator does so if we choose to
+		// use noop authentication and skip other parts of the pipeline then
+		// we need to set the session from the request headers
+		session.Header = r.Header
+		return session, nil
 	}
 
 	azh, err := d.r.PipelineAuthorizer(rl.Authorizer.Handler)


### PR DESCRIPTION
## Description

Updated the request handler to skip other parts of the pipeline when the `noop` authenticator is ran. This will no longer evaluate any `authorizers` or `mutators` as a part of the rule you configured if the `noop` authenticator is evaluated. This means moving forward if we would want to continue to use this we would need to do something like the `anonymous` authenticator in order to still trigger the other parts of the pipeline.

## Further Comments

Tests could probably be improved to check out IF a given `authorizer` or `mutator` has been ran to ensure that the `noop` authenticator will skip them.

Some tests were producing inconsistent results locally such as `TestFetchRulesFromObjectStorage` and `TestFetcherWatchRepositoryFromKubernetesConfigMap` from the `rule` pkg.
