### PR TITLE
feat(cmd/serve): add in default-shutdown-timeout flag to increase shutdown timeout on http server shutdown

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -32,4 +32,5 @@ func init() {
 
 	serveCmd.PersistentFlags().Bool("disable-telemetry", false, "Disable anonymized telemetry reports - for more information please visit https://www.ory.sh/docs/ecosystem/sqa")
 	serveCmd.PersistentFlags().Bool("sqa-opt-out", false, "Disable anonymized telemetry reports - for more information please visit https://www.ory.sh/docs/ecosystem/sqa")
+	serveCmd.PersistentFlags().Int("default-shutdown-timeout", 5, "Set the default shutdown timeout in seconds for server shutdown when trapping SIGTERM and SIGINT")
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -251,6 +251,13 @@ func RunServe(version, build, date string) func(cmd *cobra.Command, args []strin
 		adminmw.Use(telemetry)
 		publicmw.Use(telemetry)
 
+		// Override the `graceful.DefaultShutdownTimeout` value
+		graceful.DefaultShutdownTimeout = 5 * time.Second
+		defaultShutdownTimeout, _ := cmd.Flags().GetInt("default-shutdown-timeout")
+		if defaultShutdownTimeout > 0 {
+			graceful.DefaultShutdownTimeout = time.Duration(defaultShutdownTimeout) * time.Second
+		}
+
 		prometheusRepo := metrics.NewConfigurablePrometheusRepository(d, logger)
 		var wg sync.WaitGroup
 		tasks := []func(){


### PR DESCRIPTION
feat(cmd/serve): add in default-shutdown-timeout flag to increase shutdown timeout on http server shutdown
