### PR TITLE
feat(authn): add Set-Cookie header forwarding to cookie_session authe…

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -424,6 +424,12 @@
           "description": "The `subject` field in the ORY Oathkeeper authentication session is set using this JSON Path. Defaults to `subject`. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
           "type": "string",
           "default": "subject"
+        },
+        "forward_set_cookie_header": {
+          "title": "Forward Set-Cookie Header",
+          "type": "boolean",
+          "default": false,
+          "description": "When set to true, any Set-Cookie headers from the session check response will be forwarded to the client. This is useful for refreshing session cookies when the session store extends the session."
         }
       },
       "required": ["check_session_url"],

--- a/pipeline/authn/authenticator.go
+++ b/pipeline/authn/authenticator.go
@@ -43,10 +43,11 @@ func NewErrAuthenticatorMisconfigured(a Authenticator, err error) *herodot.Defau
 }
 
 type AuthenticationSession struct {
-	Subject      string                 `json:"subject"`
-	Extra        map[string]interface{} `json:"extra"`
-	Header       http.Header            `json:"header"`
-	MatchContext MatchContext           `json:"match_context"`
+	Subject        string                 `json:"subject"`
+	Extra          map[string]interface{} `json:"extra"`
+	Header         http.Header            `json:"header"`
+	ResponseHeader http.Header            `json:"response_header"` // Headers to add to the browser response
+	MatchContext   MatchContext           `json:"match_context"`
 }
 
 type MatchContext struct {
@@ -71,6 +72,22 @@ func (a *AuthenticationSession) SetHeader(key, val string) {
 		a.Header = map[string][]string{}
 	}
 	a.Header.Set(key, val)
+}
+
+// SetResponseHeader sets a header that will be added to the browser response
+func (a *AuthenticationSession) SetResponseHeader(key, val string) {
+	if a.ResponseHeader == nil {
+		a.ResponseHeader = map[string][]string{}
+	}
+	a.ResponseHeader.Set(key, val)
+}
+
+// AddResponseHeader adds a header value to the browser response (allows multiple values for same key)
+func (a *AuthenticationSession) AddResponseHeader(key, val string) {
+	if a.ResponseHeader == nil {
+		a.ResponseHeader = map[string][]string{}
+	}
+	a.ResponseHeader.Add(key, val)
 }
 
 func (a *AuthenticationSession) Copy() *AuthenticationSession {

--- a/pipeline/authn/authenticator_bearer_token.go
+++ b/pipeline/authn/authenticator_bearer_token.go
@@ -141,7 +141,7 @@ func (a *AuthenticatorBearerToken) Authenticate(r *http.Request, session *Authen
 		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
-	body, err := forwardRequestToSessionStore(a.client, r, cf)
+	resp, err := forwardRequestToSessionStore(a.client, r, cf)
 	if err != nil {
 		return err
 	}
@@ -150,16 +150,16 @@ func (a *AuthenticatorBearerToken) Authenticate(r *http.Request, session *Authen
 		subject string
 		extra   map[string]interface{}
 
-		subjectRaw = []byte(stringsx.Coalesce(gjson.GetBytes(body, cf.SubjectFrom).Raw, "null"))
-		extraRaw   = []byte(stringsx.Coalesce(gjson.GetBytes(body, cf.ExtraFrom).Raw, "null"))
+		subjectRaw = []byte(stringsx.Coalesce(gjson.GetBytes(resp.Body, cf.SubjectFrom).Raw, "null"))
+		extraRaw   = []byte(stringsx.Coalesce(gjson.GetBytes(resp.Body, cf.ExtraFrom).Raw, "null"))
 	)
 
 	if err = json.Unmarshal(subjectRaw, &subject); err != nil {
-		return helper.ErrForbidden.WithReasonf("The configured subject_from GJSON path returned an error on JSON output: %s", err.Error()).WithDebugf("GJSON path: %s\nBody: %s\nResult: %s", cf.SubjectFrom, body, subjectRaw).WithTrace(err)
+		return helper.ErrForbidden.WithReasonf("The configured subject_from GJSON path returned an error on JSON output: %s", err.Error()).WithDebugf("GJSON path: %s\nBody: %s\nResult: %s", cf.SubjectFrom, resp.Body, subjectRaw).WithTrace(err)
 	}
 
 	if err = json.Unmarshal(extraRaw, &extra); err != nil {
-		return helper.ErrForbidden.WithReasonf("The configured extra_from GJSON path returned an error on JSON output: %s", err.Error()).WithDebugf("GJSON path: %s\nBody: %s\nResult: %s", cf.ExtraFrom, body, extraRaw).WithTrace(err)
+		return helper.ErrForbidden.WithReasonf("The configured extra_from GJSON path returned an error on JSON output: %s", err.Error()).WithDebugf("GJSON path: %s\nBody: %s\nResult: %s", cf.ExtraFrom, resp.Body, extraRaw).WithTrace(err)
 	}
 
 	session.Subject = subject

--- a/pipeline/authn/authenticator_cookie_session.go
+++ b/pipeline/authn/authenticator_cookie_session.go
@@ -36,16 +36,17 @@ type AuthenticatorCookieSessionFilter struct {
 }
 
 type AuthenticatorCookieSessionConfiguration struct {
-	Only               []string          `json:"only"`
-	CheckSessionURL    string            `json:"check_session_url"`
-	PreserveQuery      bool              `json:"preserve_query"`
-	PreservePath       bool              `json:"preserve_path"`
-	ExtraFrom          string            `json:"extra_from"`
-	SubjectFrom        string            `json:"subject_from"`
-	PreserveHost       bool              `json:"preserve_host"`
-	ForwardHTTPHeaders []string          `json:"forward_http_headers"`
-	SetHeaders         map[string]string `json:"additional_headers"`
-	ForceMethod        string            `json:"force_method"`
+	Only                   []string          `json:"only"`
+	CheckSessionURL        string            `json:"check_session_url"`
+	PreserveQuery          bool              `json:"preserve_query"`
+	PreservePath           bool              `json:"preserve_path"`
+	ExtraFrom              string            `json:"extra_from"`
+	SubjectFrom            string            `json:"subject_from"`
+	PreserveHost           bool              `json:"preserve_host"`
+	ForwardHTTPHeaders     []string          `json:"forward_http_headers"`
+	SetHeaders             map[string]string `json:"additional_headers"`
+	ForceMethod            string            `json:"force_method"`
+	ForwardSetCookieHeader bool              `json:"forward_set_cookie_header"` // Forward Set-Cookie header from session check to browser response
 }
 
 func (a *AuthenticatorCookieSessionConfiguration) GetCheckSessionURL() string {
@@ -144,7 +145,7 @@ func (a *AuthenticatorCookieSession) Authenticate(r *http.Request, session *Auth
 		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
-	body, err := forwardRequestToSessionStore(a.client, r, cf)
+	resp, err := forwardRequestToSessionStore(a.client, r, cf)
 	if err != nil {
 		return err
 	}
@@ -153,20 +154,30 @@ func (a *AuthenticatorCookieSession) Authenticate(r *http.Request, session *Auth
 		subject string
 		extra   map[string]interface{}
 
-		subjectRaw = []byte(stringsx.Coalesce(gjson.GetBytes(body, cf.SubjectFrom).Raw, "null"))
-		extraRaw   = []byte(stringsx.Coalesce(gjson.GetBytes(body, cf.ExtraFrom).Raw, "null"))
+		subjectRaw = []byte(stringsx.Coalesce(gjson.GetBytes(resp.Body, cf.SubjectFrom).Raw, "null"))
+		extraRaw   = []byte(stringsx.Coalesce(gjson.GetBytes(resp.Body, cf.ExtraFrom).Raw, "null"))
 	)
 
 	if err = json.Unmarshal(subjectRaw, &subject); err != nil {
-		return helper.ErrForbidden.WithReasonf("The configured subject_from GJSON path returned an error on JSON output: %s", err.Error()).WithDebugf("GJSON path: %s\nBody: %s\nResult: %s", cf.SubjectFrom, body, subjectRaw).WithTrace(err)
+		return helper.ErrForbidden.WithReasonf("The configured subject_from GJSON path returned an error on JSON output: %s", err.Error()).WithDebugf("GJSON path: %s\nBody: %s\nResult: %s", cf.SubjectFrom, resp.Body, subjectRaw).WithTrace(err)
 	}
 
 	if err = json.Unmarshal(extraRaw, &extra); err != nil {
-		return helper.ErrForbidden.WithReasonf("The configured extra_from GJSON path returned an error on JSON output: %s", err.Error()).WithDebugf("GJSON path: %s\nBody: %s\nResult: %s", cf.ExtraFrom, body, extraRaw).WithTrace(err)
+		return helper.ErrForbidden.WithReasonf("The configured extra_from GJSON path returned an error on JSON output: %s", err.Error()).WithDebugf("GJSON path: %s\nBody: %s\nResult: %s", cf.ExtraFrom, resp.Body, extraRaw).WithTrace(err)
 	}
 
 	session.Subject = subject
 	session.Extra = extra
+
+	// Forward Set-Cookie headers from session store response to browser if configured
+	if cf.ForwardSetCookieHeader {
+		if setCookies := resp.Headers.Values("Set-Cookie"); len(setCookies) > 0 {
+			for _, cookie := range setCookies {
+				session.AddResponseHeader("Set-Cookie", cookie)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -184,7 +195,13 @@ func cookieSessionResponsible(r *http.Request, only []string) bool {
 	return false
 }
 
-func forwardRequestToSessionStore(client *http.Client, r *http.Request, cf AuthenticatorForwardConfig) (json.RawMessage, error) {
+// sessionStoreResponse holds the response from the session store
+type sessionStoreResponse struct {
+	Body    json.RawMessage
+	Headers http.Header
+}
+
+func forwardRequestToSessionStore(client *http.Client, r *http.Request, cf AuthenticatorForwardConfig) (*sessionStoreResponse, error) {
 	req, err := PrepareRequest(r, cf)
 	if err != nil {
 		return nil, err
@@ -201,11 +218,14 @@ func forwardRequestToSessionStore(client *http.Client, r *http.Request, cf Authe
 	if res.StatusCode == http.StatusOK {
 		body, err := io.ReadAll(res.Body)
 		if err != nil {
-			return json.RawMessage{}, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to fetch cookie session context from remote: %+v", err))
+			return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to fetch cookie session context from remote: %+v", err))
 		}
-		return body, nil
+		return &sessionStoreResponse{
+			Body:    body,
+			Headers: res.Header,
+		}, nil
 	} else {
-		return json.RawMessage{}, errors.WithStack(helper.ErrUnauthorized)
+		return nil, errors.WithStack(helper.ErrUnauthorized)
 	}
 }
 

--- a/pipeline/authn/authenticator_cookie_session_test.go
+++ b/pipeline/authn/authenticator_cookie_session_test.go
@@ -278,6 +278,62 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 				Extra:   map[string]interface{}{"session": map[string]interface{}{"foo": "bar"}, "identity": map[string]interface{}{"id": "123"}},
 			}, session)
 		})
+
+		t.Run("description=should forward Set-Cookie header when forward_set_cookie_header is true", func(t *testing.T) {
+			session := new(AuthenticationSession)
+			testServer, _ := makeServerWithHeaders(t, 200, `{"subject": "123", "extra": {"foo": "bar"}}`, map[string][]string{
+				"Set-Cookie": {"session=abc123; Path=/; HttpOnly", "refresh=xyz789; Path=/; Secure"},
+			})
+			err := pipelineAuthenticator.Authenticate(
+				makeRequest("GET", "/", "", map[string]string{"sessionid": "zyx"}, ""),
+				session,
+				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s", "forward_set_cookie_header": true}`, testServer.URL)),
+				nil,
+			)
+			require.NoError(t, err, "%#v", errors.Cause(err))
+			assert.Equal(t, "123", session.Subject)
+			assert.Equal(t, map[string]interface{}{"foo": "bar"}, session.Extra)
+			// Check that Set-Cookie headers are captured in ResponseHeader
+			require.NotNil(t, session.ResponseHeader)
+			setCookies := session.ResponseHeader.Values("Set-Cookie")
+			assert.Len(t, setCookies, 2)
+			assert.Contains(t, setCookies, "session=abc123; Path=/; HttpOnly")
+			assert.Contains(t, setCookies, "refresh=xyz789; Path=/; Secure")
+		})
+
+		t.Run("description=should not forward Set-Cookie header when forward_set_cookie_header is false", func(t *testing.T) {
+			session := new(AuthenticationSession)
+			testServer, _ := makeServerWithHeaders(t, 200, `{"subject": "123", "extra": {"foo": "bar"}}`, map[string][]string{
+				"Set-Cookie": {"session=abc123; Path=/; HttpOnly"},
+			})
+			err := pipelineAuthenticator.Authenticate(
+				makeRequest("GET", "/", "", map[string]string{"sessionid": "zyx"}, ""),
+				session,
+				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s", "forward_set_cookie_header": false}`, testServer.URL)),
+				nil,
+			)
+			require.NoError(t, err, "%#v", errors.Cause(err))
+			assert.Equal(t, "123", session.Subject)
+			// ResponseHeader should be nil when not forwarding cookies
+			assert.Nil(t, session.ResponseHeader)
+		})
+
+		t.Run("description=should not forward Set-Cookie header by default", func(t *testing.T) {
+			session := new(AuthenticationSession)
+			testServer, _ := makeServerWithHeaders(t, 200, `{"subject": "123", "extra": {"foo": "bar"}}`, map[string][]string{
+				"Set-Cookie": {"session=abc123; Path=/; HttpOnly"},
+			})
+			err := pipelineAuthenticator.Authenticate(
+				makeRequest("GET", "/", "", map[string]string{"sessionid": "zyx"}, ""),
+				session,
+				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s"}`, testServer.URL)),
+				nil,
+			)
+			require.NoError(t, err, "%#v", errors.Cause(err))
+			assert.Equal(t, "123", session.Subject)
+			// ResponseHeader should be nil by default (feature off)
+			assert.Nil(t, session.ResponseHeader)
+		})
 	})
 }
 
@@ -337,11 +393,21 @@ type RequestRecorder struct {
 }
 
 func makeServer(t *testing.T, statusCode int, responseBody string) (*httptest.Server, *RequestRecorder) {
+	return makeServerWithHeaders(t, statusCode, responseBody, nil)
+}
+
+func makeServerWithHeaders(t *testing.T, statusCode int, responseBody string, responseHeaders map[string][]string) (*httptest.Server, *RequestRecorder) {
 	requestRecorder := &RequestRecorder{}
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestRecorder.requests = append(requestRecorder.requests, r)
 		requestBody, _ := io.ReadAll(r.Body)
 		requestRecorder.bodies = append(requestRecorder.bodies, requestBody)
+		// Set response headers before WriteHeader
+		for key, values := range responseHeaders {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
 		w.WriteHeader(statusCode)
 		w.Write([]byte(responseBody))
 	}))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -83,6 +83,14 @@ func (d *Proxy) RoundTrip(r *http.Request) (*http.Response, error) {
 				Warn("Access request denied because roundtrip failed")
 			// don't need to return because covered in next line
 		} else {
+			// Inject ResponseHeader from session into the response to browser
+			if sess, ok := r.Context().Value(ContextKeySession).(*authn.AuthenticationSession); ok && sess.ResponseHeader != nil {
+				for key, values := range sess.ResponseHeader {
+					for _, value := range values {
+						res.Header.Add(key, value)
+					}
+				}
+			}
 			d.r.Logger().
 				WithField("granted", true).
 				WithFields(fields).

--- a/spec/config.schema.json
+++ b/spec/config.schema.json
@@ -424,6 +424,12 @@
           "description": "The `subject` field in the ORY Oathkeeper authentication session is set using this JSON Path. Defaults to `subject`. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
           "type": "string",
           "default": "subject"
+        },
+        "forward_set_cookie_header": {
+          "title": "Forward Set-Cookie Header",
+          "type": "boolean",
+          "default": false,
+          "description": "When set to true, any Set-Cookie headers from the session check response will be forwarded to the browser response. This is useful for refreshing session cookies when the session store extends the session."
         }
       },
       "required": ["check_session_url"],


### PR DESCRIPTION
This pull request adds a new `forward_set_cookie_header` configuration option to the `cookie_session` authenticator. When enabled, any `Set-Cookie` headers returned by the session check endpoint are injected into the proxied response.

### Configuration example

```yaml
authenticators:
  cookie_session:
    enabled: true
    config:
      check_session_url: https://session-store/sessions/whoami
      forward_set_cookie_header: true
```

The feature is disabled by default, preserving existing behavior.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

This feature addresses a gap when using Oathkeeper with session stores that refresh cookies on validation (e.g., Kratos's `/sessions/whoami` endpoint). In such setups, sessions may be extended server-side, but the browser cookie's `Max-Age` remains unchanged because the `Set-Cookie` header from the session store never reaches the browser (all headers are discarded by default). This effectively nullifies the benefit of session extension from the user's perspective; their session is valid in the session store, but the browser cookie expires based on its original lifetime. 

There are a few alternatives to the changes in this PR that aren't as ideal for our use case:
- **Frontend polling**: Have the main application periodically call the session check endpoint to acquire a new cookie increases latency (you are essentially duplicating the request Oathkeeper is making just to get the headers). Moreover, you would need to implement custom logic to handle _when_ to call the endpoint to avoid over-fetching.
- **Increasing the session lifespan**: Although this is a valid option, it's not something we want for our use case. Keeping sessions short and only extending them with authenticated requests is a better security posture for us.

I'm curious whether there's a reason this wasn't included originally. One could argue that forwarding `Set-Cookie` headers through a reverse proxy could have security implications depending on the trust relationship between Oathkeeper and the upstream session store. Additionally, this could introduce an opportunity for sensitive data to show up in logs. For our use case, this is not a concern. At any rate, this is an opt-in feature and disabled by default.